### PR TITLE
Removed `isTrusted` from click event properties.

### DIFF
--- a/pyseleniumjs/e2ejs.py
+++ b/pyseleniumjs/e2ejs.py
@@ -126,8 +126,7 @@ class E2EJS(object):
             options={
                 'bubbles': True,
                 'cancelBubble': False,
-                'cancelable': True,
-                'isTrusted': True
+                'cancelable': True
             }
         )
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name='pyseleniumjs',
     description='Small library with javascript utilities for official Python selenium bindings.',
-    version='1.1.7',
+    version='1.1.8',
     url='https://github.com/neetVeritas/pyselenium-js',
     author='John Nolette',
     author_email='john@neetgroup.net',


### PR DESCRIPTION
The `isTrusted` event property can not be overridden on the latest version of Chromium.