### PR TITLE
Optional Click Bubbling

### DIFF
--- a/pyseleniumjs/e2ejs.py
+++ b/pyseleniumjs/e2ejs.py
@@ -113,11 +113,13 @@ class E2EJS(object):
             element
         ))
 
-    def click(self, element):
+    def click(self, element, bubbles=False):
         """
         :Description: Execute the `click` event on the target element.
         :param element: Element for browser instance to target.
         :type element: WebElement
+        :param bubbles: If enabled, will trickle event down into child elements.
+        :type bubbles: bool
         """
         self.trigger_event(
             element=element,
@@ -127,7 +129,7 @@ class E2EJS(object):
                 'bubbles': True,
                 'cancelBubble': False,
                 'cancelable': True
-            }
+            } if bubbles else {}
         )
 
     def dbl_click(self, element):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name='pyseleniumjs',
     description='Small library with javascript utilities for official Python selenium bindings.',
-    version='1.1.9',
+    version='1.2.0',
     url='https://github.com/neetVeritas/pyselenium-js',
     author='John Nolette',
     author_email='john@neetgroup.net',

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name='pyseleniumjs',
     description='Small library with javascript utilities for official Python selenium bindings.',
-<<<<<<< HEAD
     version='1.2.0',
-=======
-    version='1.1.9',
->>>>>>> master
     url='https://github.com/neetVeritas/pyselenium-js',
     author='John Nolette',
     author_email='john@neetgroup.net',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name='pyseleniumjs',
     description='Small library with javascript utilities for official Python selenium bindings.',
-    version='1.1.8',
+    version='1.1.9',
     url='https://github.com/neetVeritas/pyselenium-js',
     author='John Nolette',
     author_email='john@neetgroup.net',


### PR DESCRIPTION
The method `click` was made to automatically include the event property `bubbles` as enabled in version 1.1.9, which caused some unaccounted for repercussions on projects testing against more intricate DOMs.

In this PR, I've made the bubbles property optional:

```python
ref.js.click(element=my_element, bubbles=True)
```